### PR TITLE
Make Mailu subnet configurable in .env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 # edit and save as .env
-
+mailu_subnet=172.19.0.0/16
 DOMAINNAME=docker.localhost
 VOLUMES_DIR=./docker/volumes
 TRAEFIK_ACME_DIR=../traefik/docker/volumes/acme

--- a/config.env.sample
+++ b/config.env.sample
@@ -4,6 +4,7 @@
 SECRET_KEY=replacesecretkey
 
 # Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
+# Should be the same as in config.env mailu_subnet
 SUBNET=172.19.0.0/16
 
 # Main mail domain
@@ -16,7 +17,7 @@ HOSTNAMES=mhn.docker.localhost,mailu.docker.localhost
 TLS_FLAVOR=mail
 
 # Authentication rate limit (per source IP address)
-AUTH_RATELIMIT=10/minute;1000/hour 
+AUTH_RATELIMIT=10/minute;1000/hour
 
 # Website name
 SITENAME=MHN Mailu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - traefik.http.routers.mailu.tls.certresolver=myresolver
       - traefik.http.routers.mailu.tls.domains[0].main=${DOMAINNAME}
       - traefik.http.routers.mailu.tls.domains[0].sans=imap.${DOMAINNAME},smtp.${DOMAINNAME}
-      - traefik.http.routers.mailu.middlewares=secheader
+      - traefik.http.routers.mailu.middlewares=secheader@file
       - traefik.http.services.mailu.loadbalancer.server.port=80
     networks:
       - traefik

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "${VOLUMES_DIR}/mailu/redis:/data"
     networks:
       - mailu
-    
+
   certdumper:
     image: mailu/traefik-certdumper:${MAILU_VERSION:-master}
     restart: unless-stopped
@@ -75,7 +75,7 @@ services:
       - "${VOLUMES_DIR}/mailu/dkim:/dkim"
     depends_on:
       - redis
-    networks:  
+    networks:
       - mailu
 
   imap:
@@ -89,7 +89,7 @@ services:
       - "${VOLUMES_DIR}/mailu/overrides:/overrides"
     depends_on:
       - front
-    networks:  
+    networks:
       - mailu
 
   smtp:
@@ -102,7 +102,7 @@ services:
       - "${VOLUMES_DIR}/mailu/overrides:/overrides"
     depends_on:
       - front
-    networks:  
+    networks:
       - mailu
 
   antispam:
@@ -117,7 +117,7 @@ services:
       - "${VOLUMES_DIR}/mailu/overrides/rspamd:/etc/rspamd/override.d"
     depends_on:
       - front
-    networks:  
+    networks:
       - mailu
 
 networks:
@@ -127,7 +127,7 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 172.19.0.0/16
+        - subnet: ${mailu_subnet}
   traefik:
     name: traefik
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - traefik.http.routers.mailu.tls.certresolver=myresolver
       - traefik.http.routers.mailu.tls.domains[0].main=${DOMAINNAME}
       - traefik.http.routers.mailu.tls.domains[0].sans=mailu.${DOMAINNAME}
-      - traefik.http.routers.mailu.middlewares=secheader
+      - traefik.http.routers.mailu.middlewares=secheader@file
       - traefik.http.services.mailu.loadbalancer.server.port=80
     networks:
       - traefik


### PR DESCRIPTION
Pulls out mailu subnet address space to .env file. 

(Also fixes middleware assignment to specify @file origin)